### PR TITLE
Removed offline Find Peers website, updated location location of new Find Peers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,6 +215,8 @@ From [Wikipedia](https://en.wikipedia.org/wiki/42_(school)):
 	- [Python script](https://github.com/rfautier/find_correction)
 - [Find Peers](https://find-peers.codam.nl/) - A list of students working on each project per campus.
 	- [source code](https://github.com/codam-coding-college/find-peers)
+- [Find Peers](https://find-peers.herokuapp.com) - Leaderboards for each campus (out of date).
+	- [source code](https://github.com/Kwevan/42-ranking)
 - [XP Calculator](https://42.tbailleu.dev)
 
 ### Awesome lists

--- a/readme.md
+++ b/readme.md
@@ -213,10 +213,8 @@ From [Wikipedia](https://en.wikipedia.org/wiki/42_(school)):
 
 - [42 Evaluators](https://www.42evaluators.com)
 	- [Python script](https://github.com/rfautier/find_correction)
-- [Find Peers](https://find-peers.herokuapp.com) - Leaderboards for each campus (seems to be offline).
-	- [source code](https://github.com/Kwevan/42-ranking)
-- [Find Peers](https://find-peers.joppekoers.nl/) - A list of students working on each project per campus.
-	- [source code](https://github.com/SirMorfield/find-peers)
+- [Find Peers](https://find-peers.codam.nl/) - A list of students working on each project per campus.
+	- [source code](https://github.com/codam-coding-college/find-peers)
 - [XP Calculator](https://42.tbailleu.dev)
 
 ### Awesome lists


### PR DESCRIPTION
Hello it's me the dev of the new find-peers

It's now being hosted on [Codam's](https://www.codam.nl/en/) servers.
To prove this you can see that find-peers.joppekoers.nl 301 redirects to find-peers.codam.nl

And the find-peers.herokuapp.com has been offline for more than 2 years now, so it's time to remove it