### PR TITLE
add 42 Luanda to the list of Africa campuses

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,7 @@ From [Wikipedia](https://en.wikipedia.org/wiki/42_(school)):
 - [1337](https://1337.ma) - Khouribga, Morocco (2018)
 - [1337](https://1337.ma) - Ben Guerir, Morocco (2019)
 - [1337MED](https://1337.ma) - Tetouan, Morocco (2022)
+- [42 Luanda](https://42luanda.com) - Luanda, Angola (2023)
 
 ### Oceania
 


### PR DESCRIPTION
This PR updates the main README file to include '**42 Luanda**' in the list of African campuses.