### PR TITLE
Add 42 PeerFinder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,7 @@ From [Wikipedia](https://en.wikipedia.org/wiki/42_(school)):
 - [Find Peers](https://find-peers.herokuapp.com) - Leaderboards for each campus (out of date).
 	- [source code](https://github.com/Kwevan/42-ranking)
 - [XP Calculator](https://42.tbailleu.dev)
-- [42 PeerFinder](https://42peerfinder.com/)
+- [42 PeerFinder](https://42peerfinder.com/) - A website for finding online students at your campus and to view cluster maps.
 
 ### Awesome lists
 

--- a/readme.md
+++ b/readme.md
@@ -215,6 +215,7 @@ From [Wikipedia](https://en.wikipedia.org/wiki/42_(school)):
 - [Find Peers](https://find-peers.herokuapp.com) - Leaderboards for each campus (out of date).
 	- [source code](https://github.com/Kwevan/42-ranking)
 - [XP Calculator](https://42.tbailleu.dev)
+- [42 PeerFinder](https://42peerfinder.com/)
 
 ### Awesome lists
 


### PR DESCRIPTION
I added [42 PeerFinder](https://42peerfinder.com/) which shows a list of online students of the user's campus and cluster maps for supported capuses.

Spoiler: I'm the creator of the tool, so feel free to add it only if you like it.